### PR TITLE
Update hep.lua

### DIFF
--- a/lua/hep.lua
+++ b/lua/hep.lua
@@ -37,29 +37,29 @@ fds.version = ProtoField.new("Version", "hep.version", ftypes.UINT8)
 hep2_proto.fields = {}
 local fds2 = hep2_proto.fields
 fds2.version = ProtoField.new("Version", "hep2.version", ftypes.UINT8)
-fds2.length = ProtoField.new("Length (Bytes)", "hep2.length", ftypes.UINT8)
-fds2.protocol_family = ProtoField.new("Protocol family", "hep2.protocol_family", ftypes.STRING)
-fds2.protocol_id = ProtoField.new("Protocol ID", "hep2.protocol_id", ftypes.STRING)
-fds2.src_port = ProtoField.new("Source port", "hep2.src_port", ftypes.UINT16)
-fds2.dst_port = ProtoField.new("Destination port", "hep2.dst_port", ftypes.UINT16)
-fds2.src_ip_address = ProtoField.new("Source IP address", "hep2.src_ip_address", ftypes.IPv4)
-fds2.dst_ip_address = ProtoField.new("Destination IP address", "hep2.dst_ip_address", ftypes.IPv4)
-fds2.timestamp = ProtoField.new("Timestamp", "hep2.timestamp", ftypes.UINT32)
-fds2.timestamp_us = ProtoField.new("Timestamp us", "hep2.timestamp_us", ftypes.UINT32)
-fds2.capture_id = ProtoField.new("Capture ID", "hep2.capture_id", ftypes.UINT16)
-fds2.payload = ProtoField.new("Payload", "hep3.payload", ftypes.STRING)
+fds2.hep_packet_size = ProtoField.new("HEP Packet Size (Bytes)", "hep2.hep_packet_size", ftypes.UINT8)
+fds2.ip_family = ProtoField.new("IP family", "hep2.ip_family", ftypes.STRING)
+fds2.transport_layer_protocol = ProtoField.new("Ingested Transport Protocol", "hep2.transport_layer_protocol", ftypes.STRING)
+fds2.source_port = ProtoField.new("Source port", "hep2.source_port", ftypes.UINT16)
+fds2.destination_port = ProtoField.new("Destination port", "hep2.destination_port", ftypes.UINT16)
+fds2.source_ip_address = ProtoField.new("Source IPv4 address", "hep2.source_ip_address", ftypes.IPv4)
+fds2.destination_ip_address = ProtoField.new("Destination IPv4 address", "hep2.destination_ip_address", ftypes.IPv4)
+fds2.timestamp_unix = ProtoField.new("Unix Timestamp (LE)", "hep2.timestamp_unix", ftypes.UINT32)
+fds2.timestamp_microsec = ProtoField.new("Timestamp µs (LE)", "hep2.timestamp_microsec", ftypes.UINT32)
+fds2.capture_node_id = ProtoField.new("Capture Node ID (LE)", "hep2.capture_node_id", ftypes.UINT16)
+fds2.payload = ProtoField.new("Encapsulated Payload", "hep3.payload", ftypes.STRING)
 
 hep3_proto.fields = {}
 local fds3 = hep3_proto.fields
-fds3.hep_id = ProtoField.new("HEP ID", "hep3.id", ftypes.STRING)
-fds3.length = ProtoField.new("Length (Bytes)", "hep3.length", ftypes.UINT16)
-fds3.protocol_family = ProtoField.new("Protocol family", "hep3.protocol_family", ftypes.STRING)
-fds3.protocol_id = ProtoField.new("Protocol ID", "hep3.protocol_id", ftypes.STRING)
-fds3.protocol_type = ProtoField.new("Protocol Type", "hep3.protocol_type", ftypes.STRING)
-fds3.src_ipv4_address = ProtoField.new("Source IPv4 address", "hep3.src_ipv4_address", ftypes.IPv4)
-fds3.dst_ipv4_address = ProtoField.new("Destination IPv4 address", "hep3.dst_ipv4_address", ftypes.IPv4)
-fds3.dst_ipv6_address = ProtoField.new("Destination IPv6 address", "hep3.dst_ipv6_address", ftypes.STRING)
-fds3.src_ipv6_address = ProtoField.new("Source IPv6 address", "hep3.src_ipv6_address", ftypes.STRING)
+fds3.hep_version = ProtoField.new("HEP Version", "hep3.version", ftypes.STRING)
+fds3.hep_packet_size = ProtoField.new("HEP Packet Size (Bytes)", "hep3.hep_packet_size", ftypes.UINT16)
+fds3.ip_family = ProtoField.new("IP family", "hep3.ip_family", ftypes.STRING)
+fds3.transport_layer_protocol = ProtoField.new("Ingested Transport Protocol", "hep3.transport_layer_protocol", ftypes.STRING)
+fds3.application_protocol = ProtoField.new("Application Protocol", "hep3.application_protocol", ftypes.STRING)
+fds3.source_ipv4_address = ProtoField.new("Source IPv4 address", "hep3.source_ipv4_address", ftypes.IPv4)
+fds3.destination_ipv4_address = ProtoField.new("Destination IPv4 address", "hep3.destination_ipv4_address", ftypes.IPv4)
+fds3.source_ipv6_address = ProtoField.new("Source IPv6 address", "hep3.source_ipv6_address", ftypes.IPv6)
+fds3.destination_ipv6_address = ProtoField.new("Destination IPv6 address", "hep3.destination_ipv6_address", ftypes.IPv6)
 fds3.vlan_id = ProtoField.new("VLAN ID", "hep3.vlan_id", ftypes.UINT16)
 fds3.group_id = ProtoField.new("Group ID", "hep3.group_id", ftypes.STRING)
 fds3.source_mac = ProtoField.new("Source MAC address", "hep3.source_mac", ftypes.STRING) -- .ETHER
@@ -67,19 +67,19 @@ fds3.destination_mac = ProtoField.new("Destination MAC address", "hep3.destinati
 fds3.ethernet_type = ProtoField.new("Ethernet Type", "hep3.ethernet_type", ftypes.UINT16)
 fds3.ip_TOS = ProtoField.new("IP TOS", "hep3.ip_TOS", ftypes.UINT8)
 fds3.tcp_flags = ProtoField.new("TCP Flags", "hep3.tcp_flags", ftypes.UINT8)
-fds3.src_port = ProtoField.new("Source port", "hep3.src_port", ftypes.UINT16)
-fds3.dst_port = ProtoField.new("Destination port", "hep3.dst_port", ftypes.UINT16)
+fds3.source_port = ProtoField.new("Source port", "hep3.source_port", ftypes.UINT16)
+fds3.destination_port = ProtoField.new("Destination port", "hep3.destination_port", ftypes.UINT16)
 fds3.mos = ProtoField.new("MOS", "hep3.mos", ftypes.UINT16)
-fds3.timestamp = ProtoField.new("Timestamp", "hep3.timestamp", ftypes.UINT32)
-fds3.timestamp_us = ProtoField.new("Timestamp µs", "hep3.timestamp_us", ftypes.UINT32)
-fds3.capture_id = ProtoField.new("Capture ID", "hep3.capture_id", ftypes.UINT32)
+fds3.timestamp_unix = ProtoField.new("Unix Timestamp", "hep3.timestamp_unix", ftypes.UINT32)
+fds3.timestamp_microsec = ProtoField.new("Timestamp µs", "hep3.timestamp_microsec", ftypes.UINT32)
+fds3.capture_node_id = ProtoField.new("Capture Node ID", "hep3.capture_node_id", ftypes.UINT32)
 fds3.auth_key = ProtoField.new("Authentication Key", "hep3.auth_key", ftypes.STRING)
 fds3.correlation_id = ProtoField.new("Correlation ID", "hep3.correlation_id", ftypes.STRING)
-fds3.payload = ProtoField.new("Payload", "hep3.payload", ftypes.STRING)
+fds3.payload = ProtoField.new("Encapsulated Payload", "hep3.payload", ftypes.STRING)
 fds3.vendor_id = ProtoField.new("Vendor ID", "hep3.vendor_id", ftypes.UINT16)
 
 --------------------------------------------------------------------------------
-function get_chunk_type(buffer, offset)
+function get_chunk_data(buffer, offset)
   return tostring(buffer(offset, FOUROCTETS))
 end
 
@@ -95,20 +95,20 @@ function add_element(subtree, buffer, offset, len, description, info)
   return offset + len
 end
 
-function process_proto_family(buffer, offset, subtree)
+function get_ip_family(buffer, offset, subtree)
   data, offset, len = get_data(buffer, offset)
   if tostring(data) == "02" then
     info = "IPv4"
   elseif tostring(data) == "0a" then
     info = "IPv6"
   else
-    info = "Unknown"
+    info = "Unknown IP Family"
   end
-  subtree:add(fds3.protocol_family, buffer(offset, len), info)
+  subtree:add(fds3.ip_family, buffer(offset, len), info)
   return offset + len
 end
 
-function process_proto_id(buffer, offset, subtree)
+function get_transport_proto_id(buffer, offset, subtree)
   data, offset, len = get_data(buffer, offset)
   if tostring(data) == "11" then
     info = "UDP"
@@ -119,134 +119,137 @@ function process_proto_id(buffer, offset, subtree)
   --else
     -- TODO; add
   end
-  subtree:add(fds3.protocol_id, buffer(offset, len), info)
+  subtree:add(fds3.transport_layer_protocol, buffer(offset, len), info)
   return offset + len
 end
 
-function process_src_ipv4_address(buffer, offset, subtree)
+function get_source_ipv4_address(buffer, offset, subtree)
   data, offset, len = get_data(buffer, offset)  
   info = data:ipv4()
-  subtree:add(fds3.src_ipv4_address, buffer(offset, len), info)
+  subtree:add(fds3.source_ipv4_address, buffer(offset, len), info)
   return offset + len
 end
 
-function process_dst_ipv4_address(buffer, offset, subtree)
+function get_destination_ipv4_address(buffer, offset, subtree)
   data, offset, len = get_data(buffer, offset)  
   info = data:ipv4()
-  subtree:add(fds3.dst_ipv4_address, buffer(offset, len), info)
+  subtree:add(fds3.destination_ipv4_address, buffer(offset, len), info)
   return offset + len
 end
 
-function decompose_ipv6(data)
-  local data = tostring(data)
-  local i = 1
-  local ret = string.sub(data, i, i+3)
-  for j=0, 6, 1
-  do
-    i = i + 4
-    ret = ret .. ":" .. string.sub(data, i, i+3)
-  end
-  ret = string.gsub(ret, ":0000", ":")
-  ret = string.gsub(ret, ":000", ":")
-  ret = string.gsub(ret, ":00", ":")
-  ret = string.gsub(ret, ":0", ":")
-  ret = string.gsub(ret, "::::", "::")
-  ret = string.gsub(ret, ":::", "::")
-  return ret
-end
+-- function decompose_ipv6(data)
+--   -- this function may only be useful in legacy versions of Wireshark
+--   local data = tostring(data)
+--   local i = 1
+--   local ret = string.sub(data, i, i+3)
+--   for j=0, 6, 1
+--   do
+--     i = i + 4
+--     ret = ret .. ":" .. string.sub(data, i, i+3)
+--   end
+--   ret = string.gsub(ret, ":0000", ":")
+--   ret = string.gsub(ret, ":000", ":")
+--   ret = string.gsub(ret, ":00", ":")
+--   ret = string.gsub(ret, ":0", ":")
+--   ret = string.gsub(ret, "::::", "::")
+--   ret = string.gsub(ret, ":::", "::")
+--   return ret
+-- end
 
-function process_src_ipv6_address(buffer, offset, subtree)
+function get_source_ipv6_address(buffer, offset, subtree)
   data, offset, len = get_data(buffer, offset)
-  local info = decompose_ipv6(data)
-  subtree:add(fds3.src_ipv6_address, buffer(offset, len), tostring(info))
+  -- local info = decompose_ipv6(data)
+  info = data:ipv6()
+  subtree:add(fds3.source_ipv6_address, buffer(offset, len), info)
   return offset + len
 end
 
-function process_dst_ipv6_address(buffer, offset, subtree)
+function get_destination_ipv6_address(buffer, offset, subtree)
   data, offset, len = get_data(buffer, offset)
-  local info = decompose_ipv6(data)
-  subtree:add(fds3.dst_ipv6_address, buffer(offset, len), tostring(info))
+  -- local info = decompose_ipv6(data)
+  info = data:ipv6()
+  subtree:add(fds3.destination_ipv6_address, buffer(offset, len), info)
   return offset + len
 end
 
-function process_src_port(buffer, offset, subtree)
-  data, offset, len = get_data(buffer, offset)
-  info = data:uint()
-  subtree:add(fds3.src_port, buffer(offset, len), info)
-  return offset + len
-end
-
-function process_dst_port(buffer, offset, subtree)
+function get_source_port(buffer, offset, subtree)
   data, offset, len = get_data(buffer, offset)
   info = data:uint()
-  subtree:add(fds3.dst_port, buffer(offset, len), info)
+  subtree:add(fds3.source_port, buffer(offset, len), info)
   return offset + len
 end
 
-function process_mos(buffer, offset, subtree)
+function get_destination_port(buffer, offset, subtree)
+  data, offset, len = get_data(buffer, offset)
+  info = data:uint()
+  subtree:add(fds3.destination_port, buffer(offset, len), info)
+  return offset + len
+end
+
+function get_mos(buffer, offset, subtree)
   data, offset, len = get_data(buffer, offset)
   info = data:uint()
   subtree:add(fds3.mos, buffer(offset, len), info)
   return offset + len
 end
 
-function process_timestamp(buffer, offset, subtree)
+function get_timestamp(buffer, offset, subtree)
   data, offset, len = get_data(buffer, offset)  
   info = data:uint()
-  subtree:add(fds3.timestamp, buffer(offset, len), info)
+  subtree:add(fds3.timestamp_unix, buffer(offset, len), info)
   return offset + len
 end
 
-function process_timestamp_us(buffer, offset, subtree)
+function get_timestamp_microsec(buffer, offset, subtree)
   data, offset, len = get_data(buffer, offset)  
   info = data:uint()
-  subtree:add(fds3.timestamp_us, buffer(offset, len), info)
+  subtree:add(fds3.timestamp_microsec, buffer(offset, len), info)
   return offset + len
 end
 
-function process_vlan_id(buffer, offset, subtree)
+function get_vlan_id(buffer, offset, subtree)
   data, offset, len = get_data(buffer, offset)  
   info = data:uint()
   subtree:add(fds3.vlan_id, buffer(offset, len), info)
   return offset + len
 end
 
-function process_group_id(buffer, offset, subtree)
+function get_group_id(buffer, offset, subtree)
   data, offset, len = get_data(buffer, offset)  
   info = data:uint()
   subtree:add(fds3.group_id, buffer(offset, len), info)
   return offset + len
 end
 
-function process_source_mac(buffer, offset, subtree)
+function get_source_mac(buffer, offset, subtree)
   data, offset, len = get_data(buffer, offset)  
   info = data:string() -- :ether() also avail, but range must be 6 bytes
   subtree:add(fds3.source_mac, buffer(offset, len), info)
   return offset + len
 end
 
-function process_destination_mac(buffer, offset, subtree)
+function get_destination_mac(buffer, offset, subtree)
   data, offset, len = get_data(buffer, offset)  
   info = data:string() -- :ether() also avail, but range must be 6 bytes
   subtree:add(fds3.destination_mac, buffer(offset, len), info)
   return offset + len
 end
 
-function process_ethernet_type(buffer, offset, subtree)
+function get_ethernet_type(buffer, offset, subtree)
   data, offset, len = get_data(buffer, offset)  
   info = data:uint()
   subtree:add(fds3.ethernet_type, buffer(offset, len), info)
   return offset + len
 end
 
-function process_tcp_flags(buffer, offset, subtree)
+function get_tcp_flags(buffer, offset, subtree)
   data, offset, len = get_data(buffer, offset)  
   info = data:uint()
   subtree:add(fds3.tcp_flags, buffer(offset, len), info)
   return offset + len
 end
 
-function process_ip_TOS(buffer, offset, subtree)
+function get_ip_TOS(buffer, offset, subtree)
   data, offset, len = get_data(buffer, offset)  
   info = data:uint()
   subtree:add(fds3.ip_TOS, buffer(offset, len), info)
@@ -261,7 +264,7 @@ function process_vendor_id(buffer, offset, subtree)
   return offset + len
 end
 
-function process_protocol_type(buffer, offset, subtree)
+function get_application_protocol(buffer, offset, subtree)
   data, offset, len = get_data(buffer, offset)
     
   if (tostring(data) == "01") then
@@ -319,62 +322,62 @@ function process_protocol_type(buffer, offset, subtree)
   elseif (tostring(data) == "64") then -- 100
     info = "LOG" -- for ingest into Loki
   else
-    info = "Unknown"
+    info = "Unknown Application Protocol"
 -- TODO; add more protocol types
   end
   
-  subtree:add(fds3.protocol_type, buffer(offset, len), info)
+  subtree:add(fds3.application_protocol, buffer(offset, len), info)
   next_offset = offset + len
   -- Careful. It must return the protocol type too. Improvable.
   return next_offset, info
 end
 
-function process_capture_id(buffer, offset, subtree)
+function get_capture_node_id(buffer, offset, subtree)
   data, offset, len = get_data(buffer, offset)  
   info = data:uint()
-  subtree:add(fds3.capture_id, buffer(offset, len), info)
+  subtree:add(fds3.capture_node_id, buffer(offset, len), info)
   return offset + len
 end
 
-function process_auth_key(buffer, offset, subtree)
+function get_auth_key(buffer, offset, subtree)
   data, offset, len = get_data(buffer, offset)
   info = data:string()
   subtree:add(fds3.auth_key, buffer(offset, len), info)
   return offset + len
 end
 
-function process_correlation_id(buffer, offset, subtree)
+function get_correlation_id(buffer, offset, subtree)
   data, offset, len = get_data(buffer, offset)
   info = data:string()
   subtree:add(fds3.correlation_id, buffer(offset, len), info)
   return offset + len
 end
 
-function process_unknown_chunk(buffer, offset)
+function skip_unknown_chunk(buffer, offset)
   data, offset, len = get_data(buffer, offset)
   return offset + len
 end
 
-function process_payload(buffer, offset, subtree, pinfo, tree, protocol_type)
+function determine_payload_content(buffer, offset, subtree, pinfo, tree, application_protocol)
   data, offset, len = get_data(buffer, offset)
   info = data:string()
   subtree:add(fds3.payload, buffer(offset, len), info)
 
-  if (protocol_type == "SIP") then
+  if (application_protocol == "SIP") then
     Dissector.get("sip"):call(buffer(offset):tvb(), pinfo, tree)
     pinfo.cols.protocol = "HEP3/SIP"
-  elseif ((protocol_type == "JSON") or (protocol_type == "JSON/RTCP") or (protocol_type == "JSON/QOS/32") or (protocol_type == "JSON/QOS/99") or (protocol_type == "MOS") or (protocol_type == "JSON/QOS/34")) then
+  elseif ((application_protocol == "JSON") or (application_protocol == "JSON/RTCP") or (application_protocol == "JSON/QOS/32") or (application_protocol == "JSON/QOS/99") or (application_protocol == "MOS") or (application_protocol == "JSON/QOS/34")) then
     Dissector.get("json"):call(buffer(offset):tvb(), pinfo, tree)
-    pinfo.cols.protocol = "HEP3/" .. protocol_type
-  elseif (protocol_type == "LOG") then
-    pinfo.cols.protocol = "HEP3/" .. protocol_type
-  elseif (protocol_type == "M2UA") then
+    pinfo.cols.protocol = "HEP3/" .. application_protocol
+  elseif (application_protocol == "LOG") then
+    pinfo.cols.protocol = "HEP3/" .. application_protocol
+  elseif (application_protocol == "M2UA") then
     Dissector.get("m2ua"):call(buffer(offset):tvb(), pinfo, tree)
     pinfo.cols.protocol = "HEP3/M2UA"
-  elseif (protocol_type == "RTP") then
+  elseif (application_protocol == "RTP") then
     Dissector.get("rtp"):call(buffer(offset):tvb(), pinfo, tree)
     pinfo.cols.protocol = "HEP3/RTP"
-  elseif (protocol_type == "M2PA") then
+  elseif (application_protocol == "M2PA") then
     Dissector.get("m2pa"):call(buffer(offset):tvb(), pinfo, tree)
     pinfo.cols.protocol = "HEP3/M2PA"
   else
@@ -392,70 +395,71 @@ function dissect_hep2(buffer, offset, subtree, pinfo, tree)
   offset = ONEOCTET
   
   total_len = buffer(offset, ONEOCTET):uint()
-  subtree:add(fds2.length, buffer(offset, ONEOCTET), total_len)
+  subtree:add(fds2.hep_packet_size, buffer(offset, ONEOCTET), total_len)
 
   offset = offset + ONEOCTET
 
-  protocol_family_buffer = buffer(offset, ONEOCTET)
+  ip_family_buffer = buffer(offset, ONEOCTET)
   
-  if (tostring(protocol_family_buffer) == "02") then
-    protocol_family = "IPv4"
-  elseif (tostring(protocol_family_buffer) == "10") then
-    protocol_family = "IPv6"
+  if (tostring(ip_family_buffer) == "02") then
+    ip_family = "IPv4"
+  elseif (tostring(ip_family_buffer) == "10") then
+    ip_family = "IPv6"
   else
-    protocol_family = "Unknown"
+    ip_family = "Unknown IP Family"
   end
   
-  subtree:add(fds2.protocol_family, buffer(offset, ONEOCTET), protocol_family)
+  subtree:add(fds2.ip_family, buffer(offset, ONEOCTET), ip_family)
 
   offset = offset + ONEOCTET
 
-  protocol_id_buffer = buffer(offset, ONEOCTET)
+  transport_layer_protocol_id_buffer = buffer(offset, ONEOCTET)
   
-  if (tostring(protocol_id_buffer) == "11") then
-    protocol_id = "UDP"
-  elseif (tostring(protocol_id_buffer) == "06") then
-    protocol_id = "TCP"
-  elseif (tostring(protocol_id_buffer) == "01") then
+  if (tostring(transport_layer_protocol_id_buffer) == "11") then
+    transport_layer_protocol = "UDP"
+  elseif (tostring(transport_layer_protocol_id_buffer) == "06") then
+    transport_layer_protocol = "TCP"
+  -- elseif (tostring(transport_layer_protocol_id_buffer) == "01") then
     -- Fixes https://github.com/sipcapture/hep-wireshark/issues/4
-    protocol_id = "ICMP"
+    -- transport_layer_protocol = "UDP (incorrect id)" --issue capture uses UDP
   else
+    transport_layer_protocol = "Unidentified Transport"
     -- TODO: Add remaining
   end
 
-  subtree:add(fds2.protocol_id, buffer(offset, ONEOCTET), protocol_id)
+  subtree:add(fds2.transport_layer_protocol, buffer(offset, ONEOCTET), transport_layer_protocol)
   offset = offset + ONEOCTET
 
-  src_port = buffer(offset, TWOOCTETS):uint()
-  subtree:add(fds2.src_port, buffer(offset, ONEOCTET), src_port)
+  source_port = buffer(offset, TWOOCTETS):uint()
+  subtree:add(fds2.source_port, buffer(offset, TWOOCTETS), source_port)
   offset = offset + TWOOCTETS
 
-  dst_port = buffer(offset, TWOOCTETS):uint()
-  subtree:add(fds2.dst_port, buffer(offset, ONEOCTET), dst_port)
+  destination_port = buffer(offset, TWOOCTETS):uint()
+  subtree:add(fds2.destination_port, buffer(offset, TWOOCTETS), destination_port)
   offset = offset + TWOOCTETS
 
   ip = buffer(offset, FOUROCTETS):ipv4()
-  subtree:add(fds2.src_ip_address, buffer(offset, ONEOCTET), ip)
+  subtree:add(fds2.source_ip_address, buffer(offset, FOUROCTETS), ip)
   offset = offset + FOUROCTETS
 
   ip = buffer(offset, FOUROCTETS):ipv4()
-  subtree:add(fds2.dst_ip_address, buffer(offset, ONEOCTET), ip)
+  subtree:add(fds2.destination_ip_address, buffer(offset, FOUROCTETS), ip)
   offset = offset + FOUROCTETS
   
-  ts = buffer(offset, FOUROCTETS):uint()
-  subtree:add(fds2.timestamp, buffer(offset, ONEOCTET), ts)
+  ts = buffer(offset, FOUROCTETS):le_uint()
+  subtree:add(fds2.timestamp_unix, buffer(offset, FOUROCTETS), ts)
   offset = offset + FOUROCTETS
   
-  ts_us = buffer(offset, FOUROCTETS):uint()
-  subtree:add(fds2.timestamp_us, buffer(offset, ONEOCTET), ts_us)
+  ts_us = buffer(offset, FOUROCTETS):le_uint()
+  subtree:add(fds2.timestamp_microsec, buffer(offset, FOUROCTETS), ts_us)
   offset = offset + FOUROCTETS
 
-  capture_id = buffer(offset, TWOOCTETS):le_uint()
-  subtree:add(fds2.capture_id, buffer(offset, ONEOCTET), capture_id)
+  capture_node_id = buffer(offset, TWOOCTETS):le_uint()
+  subtree:add(fds2.capture_node_id, buffer(offset, TWOOCTETS), capture_node_id)
   offset = offset + TWOOCTETS
 
-  data_buffer = buffer(offset, TWOOCTETS):uint()
-  subtree:add(buffer(offset, TWOOCTETS), "Unknown: " .. tostring(data_buffer))
+  data_buffer = buffer(offset, TWOOCTETS):le_uint()
+  subtree:add(buffer(offset, TWOOCTETS), "Unknown Type: " .. tostring(data_buffer))
   offset = offset + TWOOCTETS
   
   Dissector.get("sip"):call(buffer(offset):tvb(), pinfo, tree)
@@ -466,76 +470,76 @@ function dissect_hep2(buffer, offset, subtree, pinfo, tree)
 end
 
 function dissect_hep3(buffer, offset, subtree, pinfo, tree)
-  hep_id = buffer(offset, FOUROCTETS):string()
-  subtree:add(fds3.hep_id, buffer(offset, FOUROCTETS), hep_id)
+  hep_version = buffer(offset, FOUROCTETS):string()
+  subtree:add(fds3.hep_version, buffer(offset, FOUROCTETS), hep_version)
   offset = offset + FOUROCTETS
   
   total_len = buffer(offset, TWOOCTETS):uint()
-  subtree:add(fds3.length, buffer(offset, TWOOCTETS), total_len)
+  subtree:add(fds3.hep_packet_size, buffer(offset, TWOOCTETS), total_len)
 
   offset = offset + TWOOCTETS
-  chunk_type = get_chunk_type(buffer, offset)
+  chunk_type = get_chunk_data(buffer, offset)
   
   while (offset < (total_len -1)) do
     if chunk_type == "00000001" then
-      offset = process_proto_family(buffer, offset, subtree)
+      offset = get_ip_family(buffer, offset, subtree)
     elseif chunk_type == "00000002" then
-      offset = process_proto_id(buffer, offset, subtree)
+      offset = get_transport_proto_id(buffer, offset, subtree)
     elseif chunk_type == "00000003" then
-      offset = process_src_ipv4_address(buffer, offset, subtree)
+      offset = get_source_ipv4_address(buffer, offset, subtree)
     elseif chunk_type == "00000004" then
-      offset = process_dst_ipv4_address(buffer, offset, subtree)
+      offset = get_destination_ipv4_address(buffer, offset, subtree)
     elseif chunk_type == "00000005" then
-      offset = process_src_ipv6_address(buffer, offset, subtree)
+      offset = get_source_ipv6_address(buffer, offset, subtree)
     elseif chunk_type == "00000006" then
-      offset = process_dst_ipv6_address(buffer, offset, subtree)
+      offset = get_destination_ipv6_address(buffer, offset, subtree)
     elseif chunk_type == "00000007" then
-      offset = process_src_port(buffer, offset, subtree)
+      offset = get_source_port(buffer, offset, subtree)
     elseif chunk_type == "00000008" then
-      offset = process_dst_port(buffer, offset, subtree)
+      offset = get_destination_port(buffer, offset, subtree)
     elseif chunk_type == "00000009" then
-      offset = process_timestamp(buffer, offset, subtree)
+      offset = get_timestamp(buffer, offset, subtree)
     elseif chunk_type == "0000000a" then
-      offset = process_timestamp_us(buffer, offset, subtree)
+      offset = get_timestamp_microsec(buffer, offset, subtree)
     elseif chunk_type == "0000000b" then
-      offset, protocol_type = process_protocol_type(buffer, offset, subtree)
+      offset, application_protocol = get_application_protocol(buffer, offset, subtree)
     elseif chunk_type == "0000000c" then
-      offset = process_capture_id(buffer, offset, subtree)
+      offset = get_capture_node_id(buffer, offset, subtree)
     elseif chunk_type == "0000000e" then
-      offset = process_auth_key(buffer, offset, subtree)
+      offset = get_auth_key(buffer, offset, subtree)
     elseif chunk_type == "0000000f" then
-      offset = process_payload(buffer, offset, subtree, pinfo, tree, protocol_type)
+      offset = determine_payload_content(buffer, offset, subtree, pinfo, tree, application_protocol)
     elseif chunk_type == "00000010" then
       -- compressed payload. Treat as normal payload
       -- https://github.com/sipcapture/hep-wireshark/issues/5
-      offset = process_payload(buffer, offset, subtree, pinfo, tree, protocol_type)
+      offset = determine_payload_content(buffer, offset, subtree, pinfo, tree, application_protocol)
     elseif chunk_type == "00000011" then
-      offset = process_correlation_id(buffer, offset, subtree)
+      offset = get_correlation_id(buffer, offset, subtree)
     elseif chunk_type == "00000012" then
-      offset = process_vlan_id(buffer, offset, subtree)
+      offset = get_vlan_id(buffer, offset, subtree)
     elseif chunk_type == "00000013" then
-      offset = process_group_id(buffer, offset, subtree)
+      offset = get_group_id(buffer, offset, subtree)
     elseif chunk_type == "00000014" then
-      offset = process_source_mac(buffer, offset, subtree)
+      offset = get_source_mac(buffer, offset, subtree)
     elseif chunk_type == "00000015" then
-      offset = process_destination_mac(buffer, offset, subtree)
+      offset = get_destination_mac(buffer, offset, subtree)
     elseif chunk_type == "00000016" then
-      offset = process_ethernet_type(buffer, offset, subtree)
+      offset = get_ethernet_type(buffer, offset, subtree)
     elseif chunk_type == "00000017" then
-      offset = process_tcp_flags(buffer, offset, subtree)
+      offset = get_tcp_flags(buffer, offset, subtree)
     elseif chunk_type == "00000018" then
-      offset = process_ip_TOS(buffer, offset, subtree)
+      offset = get_ip_TOS(buffer, offset, subtree)
     elseif chunk_type == "00000020" then
-      offset = process_mos(buffer, offset, subtree)			
+      offset = get_mos(buffer, offset, subtree)			
     else
       -- proceed unknown chunk
         if (offset < (total_len - 1)) then
-		offset = process_unknown_chunk(buffer, offset)
+		offset = skip_unknown_chunk(buffer, offset)
         end                              
     end
 
     if (offset < (total_len - 1)) then
-      chunk_type = get_chunk_type(buffer, offset)
+      chunk_type = get_chunk_data(buffer, offset)
     end
   end -- while
 end
@@ -574,6 +578,7 @@ end
 --
 udp_table = DissectorTable.get("udp.port")
 udp_table:add(9060, hep_proto)
+udp_table:add(9063, hep_proto)
 
 tcp_table = DissectorTable.get("tcp.port")
 tcp_table:add(9062, hep_proto)


### PR DESCRIPTION
Refactoring. Clean up and disambiguation (naming) of functions and objects. 
Trimmed out manual IPv6 handling code. Use builtins. 

Fixed HEP2 quirks: unix time and microsecond time headers are now interpreted correctly (Little Endian).

Tested against Wireshark v3.2.2