### PR TITLE
Add tcp/9060 to DissectorTable

### DIFF
--- a/lua/hep.lua
+++ b/lua/hep.lua
@@ -581,4 +581,5 @@ udp_table:add(9060, hep_proto)
 udp_table:add(9063, hep_proto)
 
 tcp_table = DissectorTable.get("tcp.port")
+tcp_table:add(9060, hep_proto)
 tcp_table:add(9062, hep_proto)


### PR DESCRIPTION
heplify-server uses, by default, tcp/9060.  Plus, 9060 is the de facto port number for HEP.  Might as well add udp and tcp 9060 to the dissector tables.